### PR TITLE
[hotfix] Check document.body is up before trying to load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -127,6 +127,10 @@ export function insertBadgeWrapper (configEl) {
 }
 
 export function insertBadges () {
+  if (!document.body) {
+    return []
+  }
+
   const configEls = document.querySelectorAll('.scite-badge-config')
   for (const el of configEls) {
     insertBadgeWrapper(el)


### PR DESCRIPTION
More robuse.

In the new behavior to try and ameliorate https://github.com/scitedotai/scite/issues/753 we try to insert the badges before the document is finished loading. This means if the script is inserted in the head then `document.body` will not exist yet.

Now we will check for `document.body` before trying to set up the badges.