### PR TITLE
[fix scitedotai/scite#1263] Add option to pull DOI from meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use simply include the Javascript and CSS styles on your page. All elements w
 
 ## Settings ##
 
-`doi`: Target DOI (required)
+`doi`: Target DOI (required) (Can specify to pull from meta tag rather than hard code, see below)
 
 `show-zero`: Whether to show the badge even if we have no cites (0 0 0 0) (default: `false`)
 
@@ -23,6 +23,15 @@ To use simply include the Javascript and CSS styles on your page. All elements w
 `tooltip-placement`: Preferred tooltip placement (`left`, `right`, `top` or `bottom`) (default: `top`)
 
 `show-labels`: Whether to show tally labels (supporting, disputing, mentioning) (default: `false`)
+
+To pull the target DOI from a meta tag in the document rather than setting inline, you can use the syntax `meta:my_tag_name`. For example:
+
+```
+<meta name="article_doi" content="10.mydoi" />
+<div class="scite-badge" data-doi="meta:article_doi"></div>
+```
+
+Would use the DOI `10.mydoi`.
 
 ## API ##
 

--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -30,6 +30,19 @@ describe('getConfig', () => {
     expect(config.targetEl).toBe('.my-container')
     expect(config.insertBefore).toBe(false)
   })
+
+  it('can load DOI from meta tag', () => {
+    const metaTag = document.createElement('meta')
+    metaTag.name = 'article_doi'
+    metaTag.content = '10.dingaling'
+    document.head.appendChild(metaTag)
+
+    const el = document.createElement('el')
+    el.dataset.doi = 'meta:article_doi'
+
+    const config = main.getConfig(el)
+    expect(config.doi).toBe('10.dingaling')
+  })
 })
 
 describe('replaceTooltipsWrapper', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,17 @@ export function getConfig (el) {
   const data = el.dataset
   const config = {}
 
-  if (data.doi) {
+  if (data.doi && /^meta:/.test(data.doi)) {
+    const metaName = data.doi.split('meta:').join('')
+    const selector = `meta[name='${metaName}']`
+    const meta = document.querySelector(selector)
+
+    if (meta) {
+      config.doi = meta.getAttribute('content')
+    } else {
+      console.warn(`Scite badge could not find meta tag with name="${metaName}"`)
+    }
+  } else if (data.doi) {
     config.doi = data.doi
   }
 

--- a/src/test-page.js
+++ b/src/test-page.js
@@ -59,8 +59,10 @@ const Row = ({ doi, layout, showLabels, placement }) => (
 
 const App = () => (
   <div>
+    <meta name='article_doi' content='10.1891/0889-8391.13.2.158' />
+
     <div className='scite-badge-config' data-target-el='.special-container > .foobar' data-insert-before='true' data-doi='10.1016/j.biopsych.2005.08.012' data-tooltip-placement='right' />
-    <div className='scite-badge-config' data-target-el='.special-container' data-doi='10.1891/0889-8391.13.2.158' data-tooltip-placement='right' />
+    <div className='scite-badge-config' data-target-el='.special-container' data-doi='meta:article_doi' data-tooltip-placement='right' />
 
     <div className='badges'>
       {


### PR DESCRIPTION
Fixes: https://github.com/scitedotai/scite/issues/1263

RUP have requested that they be able to pull the DOI programmatically from a meta tag rather than specify it directly. This change should make that possible.

Comments on the interface/API welcome, we could make it a separate config option.