### PR TITLE
[fix scitedotai/scite#1371] Use position: fixed to avoid leakage

### DIFF
--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -45,29 +45,6 @@ describe('getConfig', () => {
   })
 })
 
-describe('replaceTooltipsWrapper', () => {
-  it('can insert a new wrapper', () => {
-    const initialWrapper = document.querySelector('.scite-tooltips-wrapper')
-    main.replaceTooltipsWrapper('scite-tooltips-wrapper')
-    const newWrapper = document.querySelector('.scite-tooltips-wrapper')
-
-    expect(initialWrapper).toBeNull()
-    expect(newWrapper).toBeTruthy()
-    expect(newWrapper.className).toBe('scite-tooltips-wrapper')
-  })
-
-  it('can replace an existing wrapper', () => {
-    const initialWrapper = document.querySelector('.scite-tooltips-wrapper')
-    main.replaceTooltipsWrapper('scite-tooltips-wrapper')
-    const newWrapper = document.querySelector('.scite-tooltips-wrapper')
-
-    expect(initialWrapper).toBeTruthy()
-    expect(newWrapper).toBeTruthy()
-    expect(newWrapper.className).toBe('scite-tooltips-wrapper')
-    expect(newWrapper).not.toBe(initialWrapper)
-  })
-})
-
 describe('insertBadgeWrapper', () => {
   it('inserts badge into specified element', () => {
     const myContainer = document.createElement('div')

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { createPortal } from 'react-dom'
 import classNames from 'classnames'
 import { Manager, Reference, Popper } from 'react-popper'
 import { Count, TextLogo } from 'scite-widget'
@@ -76,6 +75,7 @@ const TooltipPopper = ({
   return (
     <Popper
       placement={placement}
+      strategy='fixed'
       modifiers={[
         {
           name: 'preventOverflow',
@@ -145,8 +145,6 @@ export const Tooltip = ({ doi, tally, showZero, placement = 'top', flip, slide =
     }, 300)
   }
 
-  const tooltipWrapper = document.querySelector(`.scite-tooltip-wrapper[data-doi="${doi}"]`)
-
   return (
     <Manager>
       <Reference>
@@ -161,21 +159,16 @@ export const Tooltip = ({ doi, tally, showZero, placement = 'top', flip, slide =
           </div>
         )}
       </Reference>
-      {
-        createPortal(
-          <TooltipPopper
-            show={showTooltip && !(tally && tally.total === 0 && !showZero)}
-            doi={doi}
-            tally={tally}
-            placement={placement}
-            flip={flip}
-            slide={slide}
-            handleMouseEnter={handleMouseEnter}
-            handleMouseLeave={handleMouseLeave}
-          />,
-          tooltipWrapper
-        )
-      }
+      <TooltipPopper
+        show={showTooltip && !(tally && tally.total === 0 && !showZero)}
+        doi={doi}
+        tally={tally}
+        placement={placement}
+        flip={flip}
+        slide={slide}
+        handleMouseEnter={handleMouseEnter}
+        handleMouseLeave={handleMouseLeave}
+      />
     </Manager>
   )
 }

--- a/src/main.js
+++ b/src/main.js
@@ -54,7 +54,7 @@ export function getConfig (el) {
   return config
 }
 
-export function insertBadge (el, tooltipsWrapper) {
+export function insertBadge (el) {
   const config = getConfig(el)
   const doi = config.doi
   const showZero = config.showZero || false
@@ -69,11 +69,6 @@ export function insertBadge (el, tooltipsWrapper) {
   const flip = !config.placement
 
   unmountComponentAtNode(el)
-
-  const tooltipWrapper = document.createElement('div')
-  tooltipWrapper.className = 'scite-tooltip-wrapper'
-  tooltipWrapper.dataset.doi = doi
-  tooltipsWrapper.appendChild(tooltipWrapper)
 
   render(
     (
@@ -100,20 +95,6 @@ export function insertBadge (el, tooltipsWrapper) {
     ),
     el
   )
-}
-
-export function replaceTooltipsWrapper (className = 'scite-tooltips-wrapper') {
-  const tooltipsWrapper = document.createElement('div')
-  tooltipsWrapper.className = className
-
-  const currentWrapper = document.querySelector(`.${className}`)
-  if (currentWrapper) {
-    document.body.removeChild(currentWrapper)
-  }
-
-  document.body.appendChild(tooltipsWrapper)
-
-  return tooltipsWrapper
 }
 
 /**
@@ -159,10 +140,9 @@ export function insertBadges () {
   }
 
   const badges = document.querySelectorAll('.scite-badge')
-  const tooltipsWrapper = replaceTooltipsWrapper('scite-tooltips-wrapper')
 
   for (const badge of badges) {
-    insertBadge(badge, tooltipsWrapper)
+    insertBadge(badge)
   }
 
   return badges


### PR DESCRIPTION
Previously we would insert the tooltips at the top level of the document body to make sure that they would be visible even if the badge container was `overflow: hidden;`, but this causes problems in SPA applications where that div will be outside of a app that is being rendered and be left behind across 'pages'.

This switches to use `position: fixed;` to position the tooltips, which should have the same effect without the downside of leaking the tooltips across pages.