### PR TITLE
[noref] Update getDOI() to return a lowercased / trimmed doi

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -68,7 +68,7 @@ function getDOI (el) {
   } else if (data.doi) {
     doi = data.doi
   }
-  return doi.toLowerCase()
+  return doi.toLowerCase().trim()
 }
 
 export function insertBadge (el, tally, notices) {


### PR DESCRIPTION
## Changelog

Lowercase & trim DOIs here too... the `/papers` and `/tallies` endpoints return lowercased DOIs.

No badge:  http://www.openaccess.hacettepe.edu.tr:8080/xmlui/handle/11655/22184
Has badge: http://www.openaccess.hacettepe.edu.tr:8080/xmlui/handle/11655/21833

First one has no badge b/c its DOI is upper-case and the response DOI is in lower-case so it doesn't decide to insert the badge.

Just update `getDOI` to always return a lowercased / trimmed version to guarantee it matches what's in the API response.