### PR TITLE
[GH-2480] use latest scite-widget code that flips notice and retractions count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9798,7 +9798,7 @@
       }
     },
     "scite-widget": {
-      "version": "github:scitedotai/scite-widget#c7130b0f0041416b2ff434f7e18bd541eff94197",
+      "version": "github:scitedotai/scite-widget#25c03c08b25e4446345e64c90094fc3e00b12997",
       "from": "github:scitedotai/scite-widget#master",
       "requires": {
         "classnames": "^2.2.6",

--- a/src/test-page.js
+++ b/src/test-page.js
@@ -4,12 +4,12 @@ import './styles/test.css'
 
 const rows = [
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'vertical',
     showLabels: true
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'vertical',
     showLabels: true,
     small: true
@@ -19,40 +19,40 @@ const rows = [
     layout: 'vertical'
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'horizontal',
     showLabels: true
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'horizontal',
     showLabels: false
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'horizontal',
     showLabels: true,
     small: true
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'horizontal',
     showLabels: false,
     small: true
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'vertical',
     showLabels: false
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'vertical',
     showLabels: false,
     small: true
   },
   {
-    doi: '10.1038/nature10167',
+    doi: '10.1038/nature07404',
     layout: 'vertical',
     placement: 'left'
   }


### PR DESCRIPTION
# Change

I was using test stubs that had an equal notice and retraction count and I accidentally flipped them. This change uses the scite widget code that flips the counts and uses a doi where the counts are unequal so it doesn't happen again.



# Pics
<img width="866" alt="Screen Shot 2021-03-15 at 10 42 47 AM" src="https://user-images.githubusercontent.com/15069938/111162892-59dc1800-857b-11eb-8b42-9eb50eb4d319.png">

