### PR TITLE
[scitedotai/scite#2650] Make tooltip disable-able for extension usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use simply include the Javascript bundle on your page. All elements with the 
 
 `layout`: Either 'vertical' or 'horizontal' (default: `vertical`)
 
-`tooltip-placement`: Preferred tooltip placement (`left`, `right`, `top` or `bottom`) (default: `top`)
+`tooltip-placement`: Preferred tooltip placement (`left`, `right`, `top`, `bottom` or `none`) (default: `top`)
 
 `tooltip-slide`: Preferred tooltip position offset along edge in pixels (default: `0`, the center)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-badge",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -149,12 +149,25 @@ const TooltipPopper = ({
   )
 }
 
-export const Tooltip = ({ doi, tally, notices, showZero, placement = 'top', flip, slide = 0, children }) => {
+export const Tooltip = ({
+  doi,
+  tally,
+  notices,
+  showZero,
+  placement = 'top',
+  flip,
+  slide = 0,
+  children
+}) => {
   const [showTooltip, setShowTooltip] = useState(false)
   let hideTooltipIntvl
   let showTooltipIntvl
 
   const handleMouseEnter = () => {
+    if (placement === 'none') {
+      return
+    }
+
     if (hideTooltipIntvl) {
       clearTimeout(hideTooltipIntvl)
     }
@@ -164,6 +177,10 @@ export const Tooltip = ({ doi, tally, notices, showZero, placement = 'top', flip
   }
 
   const handleMouseLeave = () => {
+    if (placement === 'none') {
+      return
+    }
+
     if (showTooltipIntvl) {
       clearTimeout(showTooltipIntvl)
     }

--- a/src/test-page.js
+++ b/src/test-page.js
@@ -6,7 +6,8 @@ const rows = [
   {
     doi: '10.1038/nature07404',
     layout: 'vertical',
-    showLabels: true
+    showLabels: true,
+    placement: 'none'
   },
   {
     doi: '10.1038/nature07404',


### PR DESCRIPTION
Work toward: https://github.com/scitedotai/scite/issues/2650

Allows passing `data-tooltip-placement="none"` to disable the tooltip.

Also added option to the first test case so can be verified on the `npm run dev` page