### PR TITLE
[hotfix] dont render tooltip if no placement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-badge",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-badge",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Wrapper around scite-widget",
   "main": "index.js",
   "scripts": {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -189,6 +189,10 @@ export const Tooltip = ({
     }, 300)
   }
 
+  if (placement === 'none') {
+    return children
+  }
+
   return (
     <Manager>
       <Reference>


### PR DESCRIPTION
# change

ensure we don't try to render the tooltip if we don't need to. Previously we would render it and just not do anything with it - none was an invalid prop value for it. This should address what sean is seeing since there definitely wont be a tooltip now with the extension.


<img width="953" alt="Screen Shot 2021-04-22 at 1 18 40 PM" src="https://user-images.githubusercontent.com/15069938/115749444-7aaf3e80-a36d-11eb-998a-efa423602a17.png">
<img width="939" alt="Screen Shot 2021-04-22 at 1 18 29 PM" src="https://user-images.githubusercontent.com/15069938/115749447-7aaf3e80-a36d-11eb-8636-67e4b0d0cdbb.png">
