### PR TITLE
[hotfix] handle dom node owned by other react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "scite-badge",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.6.0",
+      "version": "5.6.1",
       "license": "ISC",
       "dependencies": {
         "@popperjs/core": "^2.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scite-badge",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Wrapper around scite-widget",
   "main": "index.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,13 @@ export function insertBadge (el, tally, notices) {
   //
   const flip = !config.placement
 
-  unmountComponentAtNode(el)
+  // If element is already existing on another react DOM
+  // this method can throws an exception but does remove the node
+  try {
+    unmountComponentAtNode(el)
+  } catch (_) {
+    console.warn('Scite badge: unmounting component on another react DOM')
+  }
 
   render(
     (


### PR DESCRIPTION
# Change

If there is a Dom owned by another react, unmount can throw even though it does remove the node.
Here we handle it gracefully.

# Testing

Can't really think of an automated test other than mocking that function to throw lol. Tested locally by injecting local bundle in `view-source:https://www.researchsquare.com/article/rs-17172/v1` Gonna do stage now.